### PR TITLE
Update challenge deliver method of all projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,11 @@ We hope you are eager to take one of our code challenges and show us how amazing
 
 * Please, do not open a PR with your test.
 * Please, do not fork this repo.
+* **Once you have finished the challenge, please submit your information on this amazing form:**
+  https://docs.google.com/forms/d/e/1FAIpQLSePVCWxsHZHoRqJY9-XFJHuL7iOjO00sfhZksLBmDbR0KuoLg/viewform
 
 ## Oh, and don't forget!
 
 * If you have any question or want to share any information with us, please, don't hesitate to reach your contact at ZX Ventures/Zé Delivery.
+
 

--- a/backend.md
+++ b/backend.md
@@ -68,4 +68,9 @@ Your code will be under review of the Zx's Global Engineering team. What we will
 - **Separation of concerns**
 - **Software engineering**
 
+## How to deliver it
+
+**Once you have finished the challenge, please submit your information on this amazing form:**
+  https://docs.google.com/forms/d/e/1FAIpQLSePVCWxsHZHoRqJY9-XFJHuL7iOjO00sfhZksLBmDbR0KuoLg/viewform
+
 Good luck!

--- a/data-bi.md
+++ b/data-bi.md
@@ -127,3 +127,8 @@ Draw a data flow for loading data from an e-Commerce site to a Data Mart. The da
 **Any doubts? You can open issues here in GitHub and we will get in touch**
 
 We wish you good luck! ✌️
+
+## How to deliver it
+
+**Once you have finished the challenge, please submit your information on this amazing form:**
+  https://docs.google.com/forms/d/e/1FAIpQLSePVCWxsHZHoRqJY9-XFJHuL7iOjO00sfhZksLBmDbR0KuoLg/viewform

--- a/data-science.md
+++ b/data-science.md
@@ -14,3 +14,8 @@ We expect you to create a notebook and explain how you approached the problem pr
 
 Good luck!
 
+## How to deliver it
+
+**Once you have finished the challenge, please submit your information on this amazing form:**
+  https://docs.google.com/forms/d/e/1FAIpQLSePVCWxsHZHoRqJY9-XFJHuL7iOjO00sfhZksLBmDbR0KuoLg/viewform
+

--- a/devops-sre.md
+++ b/devops-sre.md
@@ -48,4 +48,7 @@ Some statistics to check the percentage of space used by a bucket, or any other 
 
 ## How to deliver it
 
-Your code must be made available on GitHub or any other public version control software. Your project must be a standalone project (i.e. **do not fork it from our challenge or any other project**). As soon as you make it available, reach your contact at ZX Ventures in order to proceed in the recruiting process.
+Your code must be made available on GitHub or any other public version control software. Your project must be a standalone project (i.e. **do not fork it from our challenge or any other project**). 
+
+**As soon as you make it available, please submit your information on this amazing form:**
+https://docs.google.com/forms/d/e/1FAIpQLSePVCWxsHZHoRqJY9-XFJHuL7iOjO00sfhZksLBmDbR0KuoLg/viewform

--- a/frontend-mobile.md
+++ b/frontend-mobile.md
@@ -68,3 +68,8 @@ Your code will be under review of the Zx's Global Engineering team. What we will
 - **Tests**
 
 Feel free to implement it the way you feel more confortable :)
+
+## How to deliver it
+
+**Once you have finished the challenge, please submit your information on this amazing form:**
+  https://docs.google.com/forms/d/e/1FAIpQLSePVCWxsHZHoRqJY9-XFJHuL7iOjO00sfhZksLBmDbR0KuoLg/viewform

--- a/qa.md
+++ b/qa.md
@@ -31,13 +31,16 @@ We're looking for an automation test suite for an open API with ATDD approach or
 Create automated tests to get weather using Open Weather API
 [http://openweathermap.org/current](http://openweathermap.org/current) 
 
+## How to deliver it
+
+**Once you have finished the challenge, please submit your information on this amazing form:**
+  https://docs.google.com/forms/d/e/1FAIpQLSePVCWxsHZHoRqJY9-XFJHuL7iOjO00sfhZksLBmDbR0KuoLg/viewform
+
 ### Final considerations
 
 To create the tests above, you can choose any programming language, framework etc you feel more comfortable.
 Please provide a document as a summary with the guidelines of the taken approach and the made decisions (e.g selection criteria for language, framework, etc.).
 Don't forget to provide a detailed documentation on how to install and run the tests.
-
-When you're done, please send your solution to a public GIT repository and send us the link.
 
 This test will be evaluated by ZX-Ventures Engineering team.
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/9298260/72164863-3d57b500-33a5-11ea-9738-e9d14b40a346.png)

We are changing the methods of delivering the challenges to make a integration with Jira. 

Now all projects must be sent by: https://docs.google.com/forms/d/e/1FAIpQLSePVCWxsHZHoRqJY9-XFJHuL7iOjO00sfhZksLBmDbR0KuoLg/viewform link.